### PR TITLE
add ability to read multiple sheets without re-reading common data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import ssf from 'ssf';
 import { Transform } from 'stream';
 import { ReadStream } from 'tty';
 
-import { IXlsxStreamOptions, IWorksheetOptions } from './types';
+import { IXlsxStreamOptions, IXlsxStreamsOptions, IWorksheetOptions } from './types';
 
 const StreamZip = require('node-stream-zip');
 const saxStream = require('sax-stream');
@@ -11,116 +11,84 @@ function lettersToNumber(letters: string) {
     return letters.split('').reduce((r, a) => r * 26 + parseInt(a, 36) - 9, 0);
 }
 
-export function getXlsxStream(options: IXlsxStreamOptions) {
-    return new Promise<Transform | Transform[]>((resolve, reject) => {
-
-        function getTransform(formats: (string | number)[], strings: string[], header: string[]) {
-            return new Transform({
-                objectMode: true,
-                transform: (chunk, encoding, done) => {
-                    let arr = [];
-                    let formattedArr = [];
-                    let obj: any = {};
-                    let formattedObj: any = {};
-                    let parsingHeader = false;
-                    const children = chunk.children ? chunk.children.c.length ? chunk.children.c : [chunk.children.c] : [];
-                    for (let i = 0; i < children.length; i++) {
-                        const ch = children[i];
-                        if (ch.children) {
-                            let value = ch.children.v.value;
-                            if (ch.attribs.t === 's') {
-                                value = strings[value];
-                            }
-                            value = isNaN(value) ? value : Number(value);
-                            let column = ch.attribs.r.replace(/[0-9]/g, '');
-                            const index = lettersToNumber(column) - 1;
-                            if (options.withHeader) {
-                                if (!parsingHeader && header.length) {
-                                    column = header[index];
-                                } else {
-                                    header[index] = value;
-                                    parsingHeader = true;
-                                }
-                            }
-                            arr[index] = value;
-                            obj[column] = value;
-                            const formatId = ch.attribs.s ? Number(ch.attribs.s) : 0;
-                            if (formatId) {
-                                value = ssf.format(formats[formatId], value);
-                                value = isNaN(value) ? value : Number(value);
-                            }
-                            formattedArr[index] = value;
-                            formattedObj[column] = value;
+function getTransform(formats: (string | number)[], strings: string[], header: string[], withHeader?: boolean, ignoreEmpty?: boolean) {
+    return new Transform({
+        objectMode: true,
+        transform: (chunk, encoding, done) => {
+            let arr = [];
+            let formattedArr = [];
+            let obj: any = {};
+            let formattedObj: any = {};
+            let parsingHeader = false;
+            const children = chunk.children ? chunk.children.c.length ? chunk.children.c : [chunk.children.c] : [];
+            for (let i = 0; i < children.length; i++) {
+                const ch = children[i];
+                if (ch.children) {
+                    let value = ch.children.v.value;
+                    if (ch.attribs.t === 's') {
+                        value = strings[value];
+                    }
+                    value = isNaN(value) ? value : Number(value);
+                    let column = ch.attribs.r.replace(/[0-9]/g, '');
+                    const index = lettersToNumber(column) - 1;
+                    if (withHeader) {
+                        if (!parsingHeader && header.length) {
+                            column = header[index];
+                        } else {
+                            header[index] = value;
+                            parsingHeader = true;
                         }
                     }
-                    done(undefined, parsingHeader || (options.ignoreEmpty && !arr.length) ? null : {
-                        raw: {
-                            obj,
-                            arr
-                        },
-                        formatted: {
-                            obj: formattedObj,
-                            arr: formattedArr,
-                        },
-                        header,
-                    });
+                    arr[index] = value;
+                    obj[column] = value;
+                    const formatId = ch.attribs.s ? Number(ch.attribs.s) : 0;
+                    if (formatId) {
+                        value = ssf.format(formats[formatId], value);
+                        value = isNaN(value) ? value : Number(value);
+                    }
+                    formattedArr[index] = value;
+                    formattedObj[column] = value;
                 }
-            })
-        }
-
-        async function processSheets(sheetIds: (string | number | number[]), formats: (string | number)[], strings: string[]) {
-            if (Array.isArray(sheetIds)) {
-                const readStreams: Transform[] = [];
-                let streamsActive = 0;
-                sheetIds.forEach(function (idx, n) {
-                    zip.stream(`xl/worksheets/sheet${idx + 1}.xml`, (err: any, stream: ReadStream) => {
-                        readStreams[n] = stream
-                            .pipe(saxStream({
-                            strict: true,
-                            tag: 'row'
-                        }))
-                        .pipe(getTransform(formats, strings, []));
-                        streamsActive++;
-                        stream.on('end', () => {
-                            streamsActive--;
-                            if (!streamsActive) {
-                                zip.close();
-                            }
-                        });
-                    });
-                });
-                let streamsReady = false;
-                while (!streamsReady) {
-                    streamsReady = true;
-                    sheetIds.forEach(function (idx, n) {
-                        if (typeof readStreams[n] === 'undefined') {
-                            streamsReady = false;
-                        }
-                    });
-                    let p = new Promise(function (resolve) {
-                        setTimeout( function() { resolve(true); }, 10 );
-                    });
-                    await p;
-                }
-                resolve(readStreams);
-            } else {
-                zip.stream(`xl/worksheets/sheet${sheetIds}.xml`, (err: any, stream: ReadStream) => {
-                    const readStream = stream
-                        .pipe(saxStream({
-                            strict: true,
-                            tag: 'row'
-                        }))
-                        .pipe(getTransform(formats, strings, []));
-                    stream.on('end', () => {
-                        zip.close();
-                    });
-                    resolve(readStream);
-                });
             }
+            done(undefined, parsingHeader || (ignoreEmpty && !arr.length) ? null : {
+                raw: {
+                    obj,
+                    arr
+                },
+                formatted: {
+                    obj: formattedObj,
+                    arr: formattedArr,
+                },
+                header,
+            });
         }
+    })
+}
 
-        function processSharedStrings(sheetIds: (string | number | number[]), numberFormats: any, formats: (string | number)[]) {
-            const strings: string[] = [];
+export async function getXlsxStream(options: IXlsxStreamOptions) {
+    const generator = getXlsxStreams({
+        filePath: options.filePath,
+        sheets: [{
+            id: options.sheet,
+            withHeader: options.withHeader,
+            ignoreEmpty: options.ignoreEmpty
+        }]
+    });
+    const stream = await generator.next();
+    return stream.value;
+}
+
+export async function* getXlsxStreams(options: IXlsxStreamsOptions)  {
+    const sheets: string[] = [];
+    const numberFormats: any = {};
+    const formats: (string | number)[] = [];
+    const strings: string[] = [];
+    const zip = new StreamZip({
+        file: options.filePath,
+        storeEntries: true
+    });
+    await new Promise((resolve, reject) => {
+        function processSharedStrings(numberFormats: any, formats: (string | number)[]) {
             for (let i = 0; i < formats.length; i++) {
                 const format = numberFormats[formats[i]];
                 if (format) {
@@ -145,18 +113,16 @@ export function getXlsxStream(options: IXlsxStreamOptions) {
                         }
                     });
                     stream.on('end', () => {
-                        processSheets(sheetIds, formats, strings);
+                        resolve(true);
                     });
                 } else {
-                    processSheets(sheetIds, formats, strings);
+                    resolve(true);
                 }
             });
         }
 
-        function processStyles(sheetIds: (string | number | number[])) {
+        function processStyles() {
             zip.stream(`xl/styles.xml`, (err: any, stream: ReadStream) => {
-                const numberFormats: any = {};
-                const formats: (string | number)[] = [];
                 stream.pipe(saxStream({
                     strict: true,
                     tag: ['cellXfs', 'numFmts']
@@ -174,14 +140,13 @@ export function getXlsxStream(options: IXlsxStreamOptions) {
                     }
                 });
                 stream.on('end', () => {
-                    processSharedStrings(sheetIds, numberFormats, formats);
+                    processSharedStrings(numberFormats, formats);
                 });
             });
         }
 
         function processWorkbook() {
             zip.stream('xl/workbook.xml', (err: any, stream: ReadStream) => {
-                const sheets: string[] = [];
                 stream.pipe(saxStream({
                     strict: true,
                     tag: 'sheet'
@@ -190,21 +155,11 @@ export function getXlsxStream(options: IXlsxStreamOptions) {
                     sheets.push(attribs.name);
                 });
                 stream.on('end', () => {
-                    if (typeof options.sheet === 'number') {
-                        processStyles(`${options.sheet + 1}`);
-                    } else if (typeof options.sheet === 'string') {
-                        processStyles(`${sheets.indexOf(options.sheet) + 1}`);
-                    } else if (Array.isArray(options.sheet)) {
-                        processStyles(options.sheet);
-                    }
+                    processStyles();
                 });
             });
         }
 
-        const zip = new StreamZip({
-            file: options.filePath,
-            storeEntries: true
-        });
         zip.on('ready', () => {
             processWorkbook();
         });
@@ -212,6 +167,41 @@ export function getXlsxStream(options: IXlsxStreamOptions) {
             reject(new Error(err));
         });
     });
+
+    for (let i = 0; i < options.sheets.length; i++) {
+        let streamDone = false;
+        const id : string | number = options.sheets[i].id;
+        let sheetID : string = '';
+        if (typeof id === 'number') {
+            sheetID = `${id + 1}`;
+        } else if (typeof id === 'string') {
+            sheetID = `${sheets.indexOf(id) + 1}`;
+        }
+
+        yield new Promise<Transform>((resolve, reject) => {
+            zip.stream(`xl/worksheets/sheet${sheetID}.xml`, (err: any, stream: ReadStream) => {
+                const readStream = stream
+                    .pipe(saxStream({
+                        strict: true,
+                        tag: 'row'
+                    }))
+                    .pipe(getTransform(formats, strings, [], options.sheets[i].withHeader, options.sheets[i].ignoreEmpty));
+                stream.on('end', () => {
+                    if (i == (options.sheets.length - 1)) {
+                        zip.close();
+                    }
+                    streamDone = true;
+                });
+                resolve(readStream);
+            });
+        });
+
+        while (!streamDone) {
+            await new Promise((resolve, reject) => {
+                setTimeout(() => { resolve(true); }, 10);
+            })
+        }
+    }
 }
 
 export function getWorksheets(options: IWorksheetOptions) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,20 +1,10 @@
 export interface IXlsxStreamOptions {
     filePath: string;
-    sheet: string | number;
+    sheet: string | number | number[];
     withHeader?: boolean;
     ignoreEmpty?: boolean;
-    dontCloseZip?: boolean;
 }
 
 export interface IWorksheetOptions {
     filePath: string;
-}
-
-export interface IXlsxObj {
-    options: IXlsxStreamOptions;
-    zip: any;
-    zipClosed: boolean;
-    sheets: string[];
-    formats: (string | number)[];
-    strings: string[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,18 @@ export interface IXlsxStreamOptions {
     sheet: string | number;
     withHeader?: boolean;
     ignoreEmpty?: boolean;
+    dontCloseZip?: boolean;
 }
 
 export interface IWorksheetOptions {
     filePath: string;
+}
+
+export interface IXlsxObj {
+    options: IXlsxStreamOptions;
+    zip: any;
+    zipClosed: boolean;
+    sheets: string[];
+    formats: (string | number)[];
+    strings: string[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,17 @@
 export interface IXlsxStreamOptions {
     filePath: string;
-    sheet: string | number | number[];
+    sheet: string | number;
     withHeader?: boolean;
     ignoreEmpty?: boolean;
+}
+
+export interface IXlsxStreamsOptions {
+    filePath: string;
+    sheets: {
+        id: string | number;
+        withHeader?: boolean;
+        ignoreEmpty?: boolean;
+    }[];
 }
 
 export interface IWorksheetOptions {

--- a/tests/__snapshots__/xlsx-stream.spec.ts.snap
+++ b/tests/__snapshots__/xlsx-stream.spec.ts.snap
@@ -185,6 +185,49 @@ Array [
 ]
 `;
 
+exports[`reads 2 sheets from XLSX file using generator 1`] = `
+Array [
+  Object {
+    "formatted": Object {
+      "arr": Array [
+        "Sheet3",
+      ],
+      "obj": Object {
+        "A": "Sheet3",
+      },
+    },
+    "header": Array [],
+    "raw": Object {
+      "arr": Array [
+        "Sheet3",
+      ],
+      "obj": Object {
+        "A": "Sheet3",
+      },
+    },
+  },
+  Object {
+    "formatted": Object {
+      "arr": Array [
+        "Sheet1",
+      ],
+      "obj": Object {
+        "A": "Sheet1",
+      },
+    },
+    "header": Array [],
+    "raw": Object {
+      "arr": Array [
+        "Sheet1",
+      ],
+      "obj": Object {
+        "A": "Sheet1",
+      },
+    },
+  },
+]
+`;
+
 exports[`reads empty XLSX file correctly 1`] = `Array []`;
 
 exports[`throws expected bad archive error 1`] = `[Error: Archive read error]`;

--- a/tests/xlsx-stream.spec.ts
+++ b/tests/xlsx-stream.spec.ts
@@ -1,4 +1,4 @@
-import { getXlsxStream, getWorksheets } from '../src';
+import { getXlsxStream, getXlsxStreams, getWorksheets } from '../src';
 
 it('reads XLSX file correctly', async (done) => {
     const data: any = [];
@@ -116,6 +116,42 @@ it(`throws expected bad archive error`, async (done) => {
             filePath: './tests/assets/bad-archive.xlsx',
             sheet: 0,
         });
+    } catch (err) {
+        expect(err).toMatchSnapshot();
+        done();
+    }
+});
+
+it(`reads 2 sheets from XLSX file using generator`, async (done) => {
+    const data: any = [];
+    try {
+        const generator = await getXlsxStreams({
+            filePath: './tests/assets/worksheets-reordered.xlsx',
+            sheets: [
+                {
+                    id: 2,
+                    ignoreEmpty: true
+                },
+                {
+                    id: 'Sheet1',
+                    ignoreEmpty: true
+                }
+            ]
+        });
+        for await (const stream of generator) {
+            let sheetDone = false;
+            stream.on('data',x => data.push(x));
+            stream.on('end', () => {
+                sheetDone = true;
+            });
+            while (!sheetDone) {
+                await new Promise(function(resolve) {
+                    setTimeout( function() { resolve(true); }, 100);
+                });
+            }
+        }
+        expect(data).toMatchSnapshot();
+        done();
     } catch (err) {
         expect(err).toMatchSnapshot();
         done();


### PR DESCRIPTION
Hello,

Sometimes I have a need to read all possible sheets from the xlsx. Those xlsx files could be very big and it would be good to read common data (**especially** shared strings) once and then reuse this data to read all the sheets in sequence.

The proposed change splits function getXlsxStream into two:
- getXlsxObj, which initializes data common to all sheets;
- getXlsxSheetStream, which returns stream for a given sheet based on previously created obj.

The getXlsxStream uses those two new functions.