### PR TITLE
Handle the "inlineStr" cell type when reading cell values.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,9 +61,14 @@ function getTransform(formats: (string | number)[], strings: string[], dict?: IM
             for (let i = 0; i < children.length; i++) {
                 const ch = children[i];
                 if (ch.children) {
-                    let value = ch.children.v.value;
-                    if (ch.attribs.t === 's') {
-                        value = strings[value];
+                    let value: any;
+                    if (ch.attribs.t === 'inlineStr') {
+                        value = ch.children.is.children.t.value;
+                    } else {
+                        value = ch.children.v.value;
+                        if (ch.attribs.t === 's') {
+                            value = strings[value];
+                        }
                     }
                     value = isNaN(value) ? value : Number(value);
                     let column = ch.attribs.r.replace(/[0-9]/g, '');


### PR DESCRIPTION
Hi and thanks for the useful module!

I've come across a problem with a file (which I can't provide) that is apparently using the "inlineStr" cell type as documented here
https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.cell?view=openxml-2.8.1#remarks
I made some changes here to handle this type which I believe may be useful for others too.

Apologies for not updating the tests but I'm not feeling confident enough neither to modify a TypeScript project nor to prepare a proper XLSX file with this cell type.

Cheers