### PR TITLE
Update ssf to 0.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xlstream",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4369,9 +4369,9 @@
       "dev": true
     },
     "ssf": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.10.2.tgz",
-      "integrity": "sha512-rDhAPm9WyIsY8eZEKyE8Qsotb3j/wBdvMWBUsOhJdfhKGLfQidRjiBUV0y/MkyCLiXQ38FG6LWW/VYUtqlIDZQ==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
       "requires": {
         "frac": "~1.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "dependencies": {
     "node-stream-zip": "^1.9.1",
     "sax-stream": "^1.3.0",
-    "ssf": "^0.10.2"
+    "ssf": "^0.11.2"
   }
 }


### PR DESCRIPTION
I get this error when trying to parse this xlsx file

```
function isgeneral(s, i) { i = i || 0; return s.length >= 7 + i && (s.charCodeAt(i)|32) === 103 && (s.charCodeAt(i+1)|32) === 101 && (s.charCodeAt(i+2)|32) === 110 && (s.charCodeAt(i+3)|32) === 101 && (s.charCodeAt(i+4)|32) === 114 && (s.charCodeAt(i+5)|32) === 97 && (s.charCodeAt(i+6)|32) === 108; }
TypeError: Cannot read property 'length' of undefined
    at isgeneral (/Users/sam/repos/xlsx-tests/node_modules/ssf/ssf.js:16:49)
    at Object.format (/Users/sam/repos/xlsx-tests/node_modules/ssf/ssf.js:835:5)
    at Transform.transform [as _transform] (/Users/sam/repos/xlsx-tests/node_modules/xlstream/lib/index.js:136:47)
    at Transform._read (_stream_transform.js:189:10)
    at Transform._write (_stream_transform.js:177:12)
    at doWrite (_stream_writable.js:431:12)
    at writeOrBuffer (_stream_writable.js:415:5)
    at Transform.Writable.write (_stream_writable.js:305:11)
    at XmlNode.ondata (_stream_readable.js:727:22)
    at XmlNode.emit (events.js:210:5)
```

[economy-rankings.xlsx](https://github.com/Claviz/xlstream/files/5188848/economy-rankings.xlsx)

Upgrading dependency ssf to 0.11.2 solves the issue. 

